### PR TITLE
change IndexedFileInfo.Type to be an enum instead of a string

### DIFF
--- a/WASDK/IndexerTestWASDK/IndexerTestWASDK/FileIndexer.cs
+++ b/WASDK/IndexerTestWASDK/IndexerTestWASDK/FileIndexer.cs
@@ -14,6 +14,7 @@ using Windows.Storage;
 
 namespace IndexerTestWASDK
 {
+
     public class FileIndexer : INotifyPropertyChanged
     {
         public bool NeedsDisplay;
@@ -122,7 +123,7 @@ namespace IndexerTestWASDK
                     
                     string name = Path.GetFileName(file).ToLower();
                     var list = new List<IndexedFileInfo>();
-                    list.Add(new IndexedFileInfo() { Name = name, Type = "File", Path = file });
+                    list.Add(new IndexedFileInfo() { Name = name, Type = IconType.File, Path = file });
                     if (dictionary.ContainsKey(name))
                     {
                         foreach (var s in list)
@@ -152,10 +153,10 @@ namespace IndexerTestWASDK
                 }
                 string foldername = Path.GetDirectoryName(path).ToLower();
                 var flist = new List<IndexedFileInfo>();
-                flist.Add(new IndexedFileInfo() { Name = foldername, Type = "Folder", Path = path });
+                flist.Add(new IndexedFileInfo() { Name = foldername, Type = IconType.Folder, Path = path });
                 if (dictionary.ContainsKey(foldername))
                 {
-                    dictionary[foldername].Add(new IndexedFileInfo() { Name = foldername, Type = "Folder", Path = path });
+                    dictionary[foldername].Add(new IndexedFileInfo() { Name = foldername, Type = IconType.Folder, Path = path });
                 }
                 else
                 {
@@ -246,12 +247,12 @@ namespace IndexerTestWASDK
                             string path = reader.Value.ToString();
                             reader.Read();
                             reader.Read();
-                            string type = reader.Value.ToString();
+                            IconType type = (IconType)int.Parse(reader.Value.ToString());
                             reader.Read();
                             reader.Read();
                             if (Files.ContainsKey(name))
                             {
-                                Files[name].Add(new IndexedFileInfo() { Name = name, Path = path, Type= type });
+                                Files[name].Add(new IndexedFileInfo() { Name = name, Path = path, Type = type });
                             }
                             else
                             {

--- a/WASDK/IndexerTestWASDK/IndexerTestWASDK/FileIndexer.cs
+++ b/WASDK/IndexerTestWASDK/IndexerTestWASDK/FileIndexer.cs
@@ -83,46 +83,41 @@ namespace IndexerTestWASDK
             var dictionary = new Dictionary<string, List<IndexedFileInfo>>(); 
             try
             {
-                var dirs = Directory.GetDirectories(path);
-                if (dirs.Length > 0)
+                foreach (var dir in Directory.EnumerateDirectories(path))
                 {
-                    foreach (var dir in dirs)
+                    var ret = await SearchDirectory(queue, dir);
+                    foreach (var f in ret)
                     {
-                        var ret = await SearchDirectory(queue, dir);
-                        foreach (var f in ret)
+                        if (dictionary.ContainsKey(f.Key))
                         {
-                            if (dictionary.ContainsKey(f.Key))
+                            foreach (var s in f.Value)
                             {
-                                foreach (var s in f.Value)
+                                try
                                 {
-                                    try
-                                    {
-                                        dictionary[f.Key].Add(s);
+                                    dictionary[f.Key].Add(s);
 
-                                    }
-                                    catch (Exception)
-                                    {
+                                }
+                                catch (Exception)
+                                {
 
-                                    }
                                 }
                             }
-                            else
-                            {
-                                    try
-                                    {
-                                        dictionary.Add(f.Key, new List<IndexedFileInfo>(f.Value));
-                                    }
-                                    catch (Exception)
-                                    {
+                        }
+                        else
+                        {
+                                try
+                                {
+                                    dictionary.Add(f.Key, new List<IndexedFileInfo>(f.Value));
+                                }
+                                catch (Exception)
+                                {
 
-                                    }
-                            }
+                                }
                         }
                     }
                 }
 
-                var files = Directory.GetFiles(path);
-                foreach (var file in files)
+                foreach (var file in Directory.EnumerateFiles(path))
                 {
                     
                     string name = Path.GetFileName(file).ToLower();

--- a/WASDK/IndexerTestWASDK/IndexerTestWASDK/IndexedFileInfo.cs
+++ b/WASDK/IndexerTestWASDK/IndexerTestWASDK/IndexedFileInfo.cs
@@ -10,6 +10,12 @@ using Microsoft.UI.Xaml.Media;
 
 namespace IndexerTestWASDK
 {
+    public enum IconType : byte
+    {
+        File = 0,
+        Folder = 1
+    }
+
     public class IndexedFileInfo : INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
@@ -20,7 +26,7 @@ namespace IndexerTestWASDK
         }
         public string Name { get; set; }
         public string Path { get; set; }
-        public string Type { get; set; }
+        public IconType Type { get; set; }
         private ImageSource image;
 
         public ImageSource Image

--- a/WASDK/IndexerTestWASDK/IndexerTestWASDK/IndexerTestWASDK.csproj
+++ b/WASDK/IndexerTestWASDK/IndexerTestWASDK/IndexerTestWASDK.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="4.5.0" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="4.5.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="WinUIEx" Version="1.1.0" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/WASDK/IndexerTestWASDK/IndexerTestWASDK/MainWindow.xaml.cs
+++ b/WASDK/IndexerTestWASDK/IndexerTestWASDK/MainWindow.xaml.cs
@@ -267,7 +267,7 @@ namespace IndexerTestWASDK
                     try
                     {
                         StorageItemThumbnail icon = null;
-                        if (line.Type == "File")
+                        if (line.Type == IconType.File)
                         {
                             StorageFile file = await StorageFile.GetFileFromPathAsync(line.Path);
                             icon = await file.GetThumbnailAsync(ThumbnailMode.ListView);
@@ -534,7 +534,7 @@ namespace IndexerTestWASDK
                 RightClickedItem = item;
 
                 var menu = new MenuFlyout();
-                if (item.Type == "File")
+                if (item.Type == IconType.File)
                 {
                     var item1 = new MenuFlyoutItem();
                     item1.Text = "Open";


### PR DESCRIPTION
Using a byte enum instead of a string helps use less memory, less storage space, and faster comparisons.

i fucked up and another PR (#2) is in this, suck my balls git